### PR TITLE
修复双重检查锁实现单例的bug

### DIFF
--- a/app/src/main/java/com/blink/dagger/gank/util/RetrofitUtil.java
+++ b/app/src/main/java/com/blink/dagger/gank/util/RetrofitUtil.java
@@ -15,7 +15,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
 public class RetrofitUtil {
 
     private static Gank gankService;
-    private static Retrofit retrofit;
+    private static volatile Retrofit retrofit;
 
     public static Gank singletonGank (){
         if (retrofit == null) {


### PR DESCRIPTION
Java使用双重检查锁实现单例会存在Crash的可能性，在RetrofitUtil类中单例的实现方式是双重检查锁，在特定情况下会导致获取到的单例报NullPointerException。[相关文章](https://huanxi.pub/2017/02/07/JMM%20%E7%AE%80%E4%BB%8B%E5%8F%8A%20volatile%20%E7%9A%84%E8%AF%B4%E6%98%8E/)